### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/src/pages/Insight.tsx
+++ b/src/pages/Insight.tsx
@@ -86,7 +86,7 @@ export default function Insight() {
 }
 
 function wrapText(doc: jsPDF, text: string, x: number, y: number, width: number) {
-  const lines = doc.splitTextToSize(text, width)
-  lines.forEach((line) => { doc.text(line, x, y); y += 14 })
+  const lines = doc.splitTextToSize(text, width) as string[]
+  lines.forEach((line: string) => { doc.text(line, x, y); y += 14 })
   return y
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- annotate the PDF helper to avoid implicit any usage detected by TypeScript
- add Vite environment type declarations so import.meta.env is recognized during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2efae62d8832aa6115b120b84abfe