### PR TITLE
Refresh IdeaCloud UI with modern gradient layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,24 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply min-h-screen bg-slate-950 text-slate-100 antialiased;
+    background-attachment: fixed;
+  }
+
+  ::selection {
+    @apply bg-cyan-400/60 text-slate-950;
+  }
+
+  input[type='range']::-webkit-slider-thumb {
+    @apply h-4 w-4 rounded-full border-2 border-slate-900 bg-cyan-400 shadow-[0_0_0_3px_rgba(8,145,178,0.35)] transition;
+    -webkit-appearance: none;
+    margin-top: -4px;
+  }
+
+  input[type='range']::-moz-range-thumb {
+    @apply h-4 w-4 rounded-full border-2 border-slate-900 bg-cyan-400 shadow-[0_0_0_3px_rgba(8,145,178,0.35)] transition;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,21 +7,61 @@ import MapView from './pages/MapView'
 import Insight from './pages/Insight'
 
 function Layout() {
+  function navClass({ isActive }: { isActive: boolean }) {
+    return [
+      'px-5 py-2.5 rounded-full text-sm font-semibold transition duration-200',
+      'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-400',
+      isActive
+        ? 'bg-white text-slate-950 shadow-lg shadow-cyan-500/30'
+        : 'text-slate-200 hover:text-white hover:bg-white/10'
+    ].join(' ')
+  }
+
   return (
-    <div className="min-h-screen max-w-5xl mx-auto p-4 space-y-4">
-      <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">IdeaCloud</h1>
-        <nav className="space-x-4">
-          <NavLink to="/" end className={({isActive}) => isActive ? 'underline' : ''}>Capture</NavLink>
-          <NavLink to="/map" className={({isActive}) => isActive ? 'underline' : ''}>Map</NavLink>
-          <NavLink to="/insight" className={({isActive}) => isActive ? 'underline' : ''}>Insight</NavLink>
-        </nav>
-      </header>
-      <Routes>
-        <Route path="/" element={<Capture/>} />
-        <Route path="/map" element={<MapView/>} />
-        <Route path="/insight" element={<Insight/>} />
-      </Routes>
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(34,211,238,0.25),_transparent_60%)]" />
+        <div className="absolute inset-y-0 left-1/2 h-[120%] w-[120%] -translate-x-1/2 bg-[conic-gradient(at_top,_rgba(14,116,144,0.35),_rgba(79,70,229,0.15),_transparent_70%)] blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 pb-16 pt-10 sm:px-10">
+        <header className="flex flex-col gap-6 rounded-3xl border border-white/10 bg-white/5 p-6 shadow-2xl shadow-cyan-900/30 backdrop-blur xl:flex-row xl:items-center xl:justify-between">
+          <div>
+            <div className="text-sm font-medium uppercase tracking-[0.3em] text-cyan-300/80">IdeaCloud</div>
+            <h1 className="mt-2 text-3xl font-bold text-white sm:text-4xl">
+              アイデアをつないで、<span className="bg-gradient-to-r from-cyan-300 via-sky-400 to-indigo-400 bg-clip-text text-transparent">洞察</span>へ
+            </h1>
+            <p className="mt-3 max-w-xl text-sm text-slate-300 sm:text-base">
+              断片を素早くキャプチャし、関係性を俯瞰しながら次の一手を導き出すモダンなナレッジワークスペースです。
+            </p>
+          </div>
+          <nav className="flex flex-wrap items-center gap-2 rounded-full border border-white/10 bg-slate-900/60 p-2 shadow-inner shadow-cyan-500/10 backdrop-blur">
+            <NavLink to="/" end className={navClass}>
+              Capture
+            </NavLink>
+            <NavLink to="/map" className={navClass}>
+              Map
+            </NavLink>
+            <NavLink to="/insight" className={navClass}>
+              Insight
+            </NavLink>
+          </nav>
+        </header>
+
+        <main className="mt-10 flex-1">
+          <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/40 p-6 shadow-[0_30px_80px_-40px_rgba(14,116,144,0.8)] backdrop-blur">
+            <Routes>
+              <Route path="/" element={<Capture />} />
+              <Route path="/map" element={<MapView />} />
+              <Route path="/insight" element={<Insight />} />
+            </Routes>
+          </div>
+        </main>
+
+        <footer className="mt-12 text-xs text-slate-400/80">
+          © {new Date().getFullYear()} IdeaCloud. Crafted for creative builders.
+        </footer>
+      </div>
     </div>
   )
 }

--- a/src/pages/Capture.tsx
+++ b/src/pages/Capture.tsx
@@ -1,13 +1,16 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { db, IdeaFragment } from '../db/db'
 import { v4 as uuid } from 'uuid'
 import { tagIdea } from '../services/ai'
+
+const STAR_LABELS = ['ひらめきの種', '少し気になる', '注目アイデア', '最優先メモ']
 
 export default function Capture() {
   const [text, setText] = useState('')
   const [star, setStar] = useState(0)
   const [toast, setToast] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const starLabel = useMemo(() => STAR_LABELS[star] ?? STAR_LABELS[0], [star])
 
   async function onSubmit() {
     try {
@@ -16,51 +19,140 @@ export default function Capture() {
       const { tags } = await tagIdea(text)
       const frag: IdeaFragment = { id, text, createdAt: now, star, tags, rel: [] }
       await db.fragments.add(frag)
-      setText(''); setStar(0)
+      setText('')
+      setStar(0)
       setToast(`保存しました: ${tags.join(', ')}`)
-      setTimeout(() => setToast(null), 1500)
+      setTimeout(() => setToast(null), 1800)
+      setError(null)
     } catch (e: any) {
       setError(e.message || String(e))
     }
   }
 
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); if (text.trim()) onSubmit() }
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      if (text.trim()) onSubmit()
+    }
   }
 
   return (
-    <div className="space-y-4">
-      <textarea className="w-full p-3 border rounded" rows={3}
-        placeholder="一行メモ（断片）を入力..." value={text}
-        onChange={e => setText(e.target.value)} onKeyDown={onKeyDown}/>
-      <div className="flex items-center gap-3">
-        <label>重要度:</label>
-        <input type="range" min={0} max={3} value={star} onChange={e => setStar(parseInt(e.target.value))} />
-        <button onClick={onSubmit} disabled={!text.trim()} className="px-3 py-2 border rounded">保存</button>
-      </div>
-      {toast && <div className="text-sm">{toast}</div>}
-      {error && <div className="text-sm text-red-600">{error}</div>}
-      <RecentList/>
+    <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_320px]">
+      <section className="space-y-6">
+        <div className="relative overflow-hidden rounded-3xl border border-white/5 bg-white/5 p-6 shadow-[0_25px_60px_-30px_rgba(8,145,178,0.7)]">
+          <div className="pointer-events-none absolute -top-24 left-1/2 h-48 w-72 -translate-x-1/2 rounded-full bg-cyan-400/30 blur-3xl" />
+          <div className="relative space-y-6">
+            <div>
+              <h2 className="text-xl font-semibold text-white sm:text-2xl">アイデアの断片をキャプチャ</h2>
+              <p className="mt-2 text-sm text-slate-300">
+                思いついた瞬間に書き留めましょう。Enterで即保存、Shift + Enterで改行できます。
+              </p>
+            </div>
+            <div className="space-y-3">
+              <label className="block text-xs font-semibold uppercase tracking-[0.3em] text-cyan-200/80">fragment</label>
+              <textarea
+                className="min-h-[160px] w-full resize-none rounded-2xl border border-white/10 bg-slate-950/60 p-5 text-base text-slate-100 placeholder:text-slate-400 focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-500/40"
+                rows={4}
+                placeholder="一行メモ（断片）を入力..."
+                value={text}
+                onChange={e => setText(e.target.value)}
+                onKeyDown={onKeyDown}
+              />
+            </div>
+            <div className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-slate-900/70 p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-[0.25em] text-cyan-200/70">priority</div>
+                <div className="mt-1 text-sm text-slate-200">{starLabel}</div>
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+                <div className="flex items-center justify-between gap-3 text-base font-medium text-amber-300">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <span key={i} className={i <= star ? 'text-amber-300' : 'text-slate-500'}>
+                      ★
+                    </span>
+                  ))}
+                </div>
+                <input
+                  type="range"
+                  min={0}
+                  max={3}
+                  value={star}
+                  onChange={e => setStar(parseInt(e.target.value))}
+                  className="h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-700 accent-cyan-400"
+                />
+              </div>
+            </div>
+            <div className="flex flex-col-reverse items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="space-y-1 text-xs text-slate-400">
+                <p>Shift + Enter で改行。AIがタグを自動提案します。</p>
+                {error && <p className="text-red-400">{error}</p>}
+              </div>
+              <button
+                onClick={onSubmit}
+                disabled={!text.trim()}
+                className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-cyan-400 via-sky-400 to-blue-500 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/30 transition hover:from-cyan-300 hover:to-blue-400 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                保存してタグ付け
+              </button>
+            </div>
+          </div>
+        </div>
+        {toast && (
+          <div className="rounded-2xl border border-cyan-400/40 bg-cyan-500/10 px-4 py-3 text-sm text-cyan-200 shadow-inner shadow-cyan-500/20">
+            {toast}
+          </div>
+        )}
+      </section>
+
+      <aside className="space-y-4">
+        <RecentList />
+      </aside>
     </div>
   )
 }
 
 function RecentList() {
   const [list, setList] = useState<IdeaFragment[]>([])
+
   useEffect(() => {
     const load = async () => setList(await db.fragments.orderBy('createdAt').reverse().limit(10).toArray())
-    load(); const id = setInterval(load, 1000); return () => clearInterval(id)
+    load()
+    const id = setInterval(load, 1200)
+    return () => clearInterval(id)
   }, [])
+
   return (
-    <div className="mt-6">
-      <h2 className="font-semibold mb-2">最近の断片</h2>
-      <ul className="space-y-2">{list.map(f => (
-        <li key={f.id} className="p-2 border rounded">
-          <div className="text-sm opacity-70">{new Date(f.createdAt).toLocaleString()}</div>
-          <div>{f.text}</div>
-          <div className="text-xs opacity-70">tags: {f.tags.join(', ')}</div>
-        </li>
-      ))}</ul>
+    <div className="rounded-3xl border border-white/5 bg-white/5 p-5 shadow-[0_20px_40px_-30px_rgba(14,165,233,0.7)]">
+      <h2 className="text-base font-semibold text-white">最近の断片</h2>
+      <p className="mt-1 text-xs text-slate-300">最新10件のメモがタイムラインで表示されます。</p>
+      <ul className="mt-4 space-y-3">
+        {list.length === 0 && (
+          <li className="rounded-2xl border border-dashed border-white/10 bg-slate-900/50 p-4 text-sm text-slate-400">
+            まだ保存された断片がありません。最初のひらめきを記録しましょう。
+          </li>
+        )}
+        {list.map(f => (
+          <li
+            key={f.id}
+            className="group rounded-2xl border border-white/10 bg-slate-900/60 p-4 transition hover:border-cyan-300/60 hover:bg-slate-900/80"
+          >
+            <div className="flex items-center justify-between text-xs text-slate-400">
+              <span>{new Date(f.createdAt).toLocaleString()}</span>
+              <span className="rounded-full bg-slate-800/80 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-300">
+                {f.star + 1} ★
+              </span>
+            </div>
+            <p className="mt-2 text-sm text-slate-100">{f.text}</p>
+            <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-cyan-200">
+              {f.tags.map(tag => (
+                <span key={tag} className="rounded-full bg-cyan-500/10 px-2 py-0.5">
+                  #{tag}
+                </span>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/src/pages/Insight.tsx
+++ b/src/pages/Insight.tsx
@@ -1,29 +1,47 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { db, IdeaFragment } from '../db/db'
 import { insightForCluster } from '../services/ai'
 import { jsPDF } from 'jspdf'
 
+type InsightPayload = { summary: string; next_steps: string[]; titles: string[] }
+
 export default function Insight() {
   const [rows, setRows] = useState<IdeaFragment[]>([])
-  const [ins, setIns] = useState<{summary:string, next_steps:string[], titles:string[]}>()
+  const [ins, setIns] = useState<InsightPayload | null>(null)
+  const [loading, setLoading] = useState(false)
 
-  useEffect(() => { db.fragments.toArray().then(setRows) }, [])
+  useEffect(() => {
+    db.fragments.toArray().then(setRows)
+  }, [])
 
   async function genInsight() {
-    const texts = rows.map(r => r.text)
-    setIns(await insightForCluster(texts))
+    try {
+      setLoading(true)
+      const texts = rows.map(r => r.text)
+      if (!texts.length) {
+        setIns(null)
+        return
+      }
+      const result = await insightForCluster(texts)
+      setIns(result)
+    } finally {
+      setLoading(false)
+    }
   }
 
   function exportJson() {
     const blob = new Blob([JSON.stringify(rows, null, 2)], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
-    a.href = url; a.download = `ideacloud-export-${Date.now()}.json`; a.click()
+    a.href = url
+    a.download = `ideacloud-export-${Date.now()}.json`
+    a.click()
     URL.revokeObjectURL(url)
   }
 
   async function importJson(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0]; if (!file) return
+    const file = e.target.files?.[0]
+    if (!file) return
     const text = await file.text()
     const arr = JSON.parse(text) as IdeaFragment[]
     await db.transaction('rw', db.fragments, async () => {
@@ -36,57 +54,135 @@ export default function Insight() {
   function exportPdf() {
     const doc = new jsPDF({ unit: 'pt', format: 'a4' })
     let y = 40
-    doc.setFontSize(16); doc.text('IdeaCloud Insight', 40, y); y += 24
+    doc.setFontSize(16)
+    doc.text('IdeaCloud Insight', 40, y)
+    y += 24
     doc.setFontSize(12)
     if (ins) {
-      doc.text('要約:', 40, y); y += 18
+      doc.text('要約:', 40, y)
+      y += 18
       y = wrapText(doc, ins.summary, 40, y, 520) + 10
-      doc.text('次の一手:', 40, y); y += 18
-      ins.next_steps.forEach(s => { y = wrapText(doc, '・' + s, 50, y, 510) + 8 })
+      doc.text('次の一手:', 40, y)
+      y += 18
+      ins.next_steps.forEach(s => {
+        y = wrapText(doc, '・' + s, 50, y, 510) + 8
+      })
       y += 8
-      doc.text('タイトル候補:', 40, y); y += 18
-      ins.titles.forEach(t => { y = wrapText(doc, '・' + t, 50, y, 510) + 8 })
+      doc.text('タイトル候補:', 40, y)
+      y += 18
+      ins.titles.forEach(t => {
+        y = wrapText(doc, '・' + t, 50, y, 510) + 8
+      })
     } else {
       doc.text('まだインサイトが生成されていません。', 40, y)
     }
     doc.save(`ideacloud-insight-${Date.now()}.pdf`)
   }
 
+  const statCards = useMemo(
+    () => [
+      { label: '断片総数', value: rows.length },
+      { label: '保存済みクラスタ', value: new Set(rows.map(r => r.clusterId).filter(Boolean)).size },
+      { label: 'タグ多様性', value: new Set(rows.flatMap(r => r.tags || [])).size }
+    ],
+    [rows]
+  )
+
   return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap gap-2">
-        <button onClick={genInsight} className="px-3 py-2 border rounded">インサイト生成</button>
-        <button onClick={exportJson} className="px-3 py-2 border rounded">JSONエクスポート</button>
-        <label className="px-3 py-2 border rounded cursor-pointer">
-          JSONインポート<input type="file" accept="application/json" onChange={importJson} className="hidden" />
-        </label>
-        <button onClick={exportPdf} className="px-3 py-2 border rounded">PDF出力</button>
-      </div>
-
-      <div className="p-3 border rounded">
-        <div>断片総数: <b>{rows.length}</b></div>
-      </div>
-
-      {ins && (
-        <div className="p-3 border rounded space-y-2">
-          <div className="font-semibold">今週の要約</div>
-          <p>{ins.summary}</p>
-          <div className="font-semibold">次の一手</div>
-          <ul className="list-disc pl-6">
-            {ins.next_steps.map((s, i) => <li key={i}>{s}</li>)}
-          </ul>
-          <div className="font-semibold">タイトル候補</div>
-          <ul className="list-disc pl-6">
-            {ins.titles.map((s, i) => <li key={i}>{s}</li>)}
-          </ul>
+    <div className="space-y-10">
+      <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-[0_25px_60px_-30px_rgba(59,130,246,0.6)]">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-white">インサイトダッシュボード</h2>
+            <p className="mt-2 max-w-xl text-sm text-slate-300">
+              AIが要約・次のアクション・タイトル案を提案します。データをエクスポートして他のツールと連携することもできます。
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <button
+              onClick={genInsight}
+              disabled={loading}
+              className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-sky-400 via-indigo-400 to-purple-500 px-5 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-indigo-500/30 transition hover:from-sky-300 hover:to-purple-400 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {loading ? '生成中…' : 'インサイトを生成'}
+            </button>
+            <button
+              onClick={exportJson}
+              className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-slate-900/60 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/60 hover:text-white"
+            >
+              JSONエクスポート
+            </button>
+            <label className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-dashed border-white/20 bg-slate-900/60 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/60 hover:text-white">
+              JSONインポート
+              <input type="file" accept="application/json" onChange={importJson} className="hidden" />
+            </label>
+            <button
+              onClick={exportPdf}
+              className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-slate-900/60 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/60 hover:text-white"
+            >
+              PDF出力
+            </button>
+          </div>
         </div>
-      )}
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-3">
+        {statCards.map(card => (
+          <div key={card.label} className="rounded-2xl border border-white/10 bg-slate-900/60 p-5 shadow-inner shadow-sky-500/10">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.3em] text-cyan-200/70">{card.label}</div>
+            <div className="mt-2 text-2xl font-bold text-white">{card.value}</div>
+          </div>
+        ))}
+      </section>
+
+      <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-[0_20px_50px_-35px_rgba(236,72,153,0.5)]">
+        {rows.length === 0 ? (
+          <div className="text-sm text-slate-300">まずは断片を追加して、洞察の材料をためましょう。</div>
+        ) : ins ? (
+          <div className="space-y-8">
+            <div>
+              <h3 className="text-lg font-semibold text-white">今週の要約</h3>
+              <p className="mt-2 text-sm leading-relaxed text-slate-200">{ins.summary}</p>
+            </div>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <div className="rounded-2xl border border-white/10 bg-slate-900/70 p-5">
+                <h4 className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-300/80">次の一手</h4>
+                <ul className="mt-3 space-y-2 text-sm text-slate-200">
+                  {ins.next_steps.map((s, i) => (
+                    <li key={i} className="rounded-xl border border-emerald-300/20 bg-emerald-500/10 px-3 py-2">
+                      {s}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-slate-900/70 p-5">
+                <h4 className="text-sm font-semibold uppercase tracking-[0.2em] text-fuchsia-300/80">タイトル候補</h4>
+                <ul className="mt-3 space-y-2 text-sm text-slate-200">
+                  {ins.titles.map((s, i) => (
+                    <li key={i} className="rounded-xl border border-fuchsia-300/20 bg-fuchsia-500/10 px-3 py-2">
+                      {s}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3 text-sm text-slate-300">
+            <p>まだインサイトが生成されていません。上のボタンから生成を開始しましょう。</p>
+            {loading && <p className="text-cyan-200">AIが分析中です…</p>}
+          </div>
+        )}
+      </section>
     </div>
   )
 }
 
 function wrapText(doc: jsPDF, text: string, x: number, y: number, width: number) {
   const lines = doc.splitTextToSize(text, width) as string[]
-  lines.forEach((line: string) => { doc.text(line, x, y); y += 14 })
+  lines.forEach((line: string) => {
+    doc.text(line, x, y)
+    y += 14
+  })
   return y
 }

--- a/src/pages/MapView.tsx
+++ b/src/pages/MapView.tsx
@@ -18,22 +18,25 @@ export default function MapView() {
 
   async function recalcClusters() {
     try {
-      setBusy(true); setError(null)
+      setBusy(true)
+      setError(null)
       const items = await db.fragments.toArray()
       const out = await clusterize(items.map(f => ({ id: f.id, text: f.text, tags: f.tags || [] })))
       await db.clusters.clear()
       const toInsert: CloudCluster[] = out.map(c => ({
-        id: c.id, label: c.label, tagHints: c.keywords || [],
-        fragmentIds: c.memberIds || [], score: 1
+        id: c.id,
+        label: c.label,
+        tagHints: c.keywords || [],
+        fragmentIds: c.memberIds || [],
+        score: 1
       }))
       await db.clusters.bulkAdd(toInsert)
       const map: Record<string, string> = {}
-      out.forEach(c => c.memberIds.forEach(id => map[id] = c.id))
+      out.forEach(c => c.memberIds.forEach(id => (map[id] = c.id)))
       await db.transaction('rw', db.fragments, async () => {
         for (const f of items) await db.fragments.update(f.id, { clusterId: map[f.id] })
       })
       await load()
-      await render()
     } catch (e: any) {
       setError(e.message || String(e))
     } finally {
@@ -41,53 +44,106 @@ export default function MapView() {
     }
   }
 
-  function buildElements(frags: IdeaFragment[]): ElementsDefinition {
-    const nodes = frags.map(f => ({ data: { id: f.id, label: f.text.slice(0, 28) || '…', clusterId: f.clusterId || 'none' } }))
+  function buildElements(list: IdeaFragment[]): ElementsDefinition {
+    const nodes = list.map(f => ({
+      data: { id: f.id, label: f.text.slice(0, 32) || '…', clusterId: f.clusterId || 'none' }
+    }))
     const edges: any[] = [] // MVP: 関連は将来
     return { nodes, edges }
   }
 
-  function nodeStyle(frags: IdeaFragment[]) {
-    const ids = Array.from(new Set(frags.map(f => f.clusterId || 'none')))
-    const palette = ['#60a5fa','#34d399','#fbbf24','#f87171','#a78bfa','#f472b6','#22d3ee','#f59e0b','#84cc16']
+  function nodeStyle(list: IdeaFragment[]) {
+    const ids = Array.from(new Set(list.map(f => f.clusterId || 'none')))
+    const palette = ['#38bdf8', '#34d399', '#fbbf24', '#f472b6', '#a855f7', '#fb7185', '#22d3ee', '#f97316', '#84cc16']
     const colorBy: Record<string, string> = {}
-    ids.forEach((id, i) => colorBy[id] = palette[i % palette.length])
+    ids.forEach((id, i) => (colorBy[id] = palette[i % palette.length]))
     return {
       label: 'data(label)',
-      'font-size': 10,
+      'font-size': 12,
       'text-wrap': 'wrap',
-      width: 10, height: 10,
-      'background-color': (ele: any) => colorBy[ele.data('clusterId')] || '#94a3b8'
+      'text-max-width': 120,
+      width: 16,
+      height: 16,
+      'border-width': 2,
+      'border-color': 'rgba(15,118,110,0.6)',
+      'background-color': (ele: any) => colorBy[ele.data('clusterId')] || '#94a3b8',
+      'color': '#0f172a',
+      'font-weight': '600',
+      'text-outline-color': '#0f172a',
+      'text-outline-width': 3
     } as any
   }
 
-  async function render() {
+  function render() {
     const cy = cytoscape({
       container: ref.current!,
       elements: buildElements(frags),
-      layout: { name: 'cose' },
+      layout: { name: 'cose', animate: true, idealEdgeLength: 120, nodeRepulsion: 8000 },
       style: [
         { selector: 'node', style: nodeStyle(frags) },
-        { selector: 'edge', style: { width: 1 } }
+        { selector: 'edge', style: { width: 1.5, 'line-color': 'rgba(148,163,184,0.35)' } }
       ]
     })
     setReady(true)
     return () => cy.destroy()
   }
 
-  useEffect(() => { load() }, [])
-  useEffect(() => { if (frags.length) render() }, [frags])
+  useEffect(() => {
+    load()
+  }, [])
+
+  useEffect(() => {
+    if (!frags.length || !ref.current) return
+    const cleanup = render()
+    return cleanup
+  }, [frags])
+
+  const stats = [
+    { label: '断片', value: frags.length },
+    { label: 'クラスタ', value: clusters.length },
+    {
+      label: 'タグ多様性',
+      value: new Set(frags.flatMap(f => f.tags || [])).size
+    }
+  ]
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center gap-2">
-        <button onClick={recalcClusters} disabled={busy} className="px-3 py-2 border rounded">
-          {busy ? '再計算中…' : 'クラスタ再計算'}
-        </button>
-        {error && <div className="text-red-600 text-sm">{error}</div>}
+    <div className="space-y-8">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold text-white">アイデアクラウドマップ</h2>
+          <p className="max-w-2xl text-sm text-slate-300">
+            断片どうしの近さからパターンを発見しましょう。クラスタ再計算でAIが新しい関連性を提案します。
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            onClick={recalcClusters}
+            disabled={busy}
+            className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-emerald-400 via-cyan-400 to-sky-500 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:from-emerald-300 hover:to-sky-400 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {busy ? '再計算中…' : 'クラスタを再計算'}
+          </button>
+          {error && <div className="rounded-full border border-red-500/40 bg-red-500/10 px-3 py-1 text-xs text-red-200">{error}</div>}
+        </div>
       </div>
-      <div className="h-[70vh] border rounded" ref={ref}>
-        {!ready && <div className="p-2 text-sm">読み込み中...</div>}
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        {stats.map(stat => (
+          <div key={stat.label} className="rounded-2xl border border-white/10 bg-slate-900/60 p-4 text-center shadow-inner shadow-cyan-500/10">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.3em] text-cyan-200/70">{stat.label}</div>
+            <div className="mt-2 text-2xl font-bold text-white">{stat.value}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/60 shadow-[0_25px_60px_-35px_rgba(14,165,233,0.7)]">
+        <div ref={ref} className="h-[70vh]" />
+        {!ready && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-sm text-slate-300">
+            読み込み中...
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- redesign the global shell with gradient backgrounds, hero header, and elevated navigation to mirror modern solomaker.dev aesthetics
- restyle the capture workspace with glassmorphism cards, enhanced priority controls, and richer recent fragment list visuals
- modernize the map and insight dashboards with stat cards, gradient CTAs, and refined cytoscape rendering polish

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2fe4d6a94832aa0eb04952499ce9e