### PR TITLE
Fix insight generation and improve export encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 dist
+tsconfig.tsbuildinfo
 .env*
 !.env.production
 !.env.example


### PR DESCRIPTION
## Summary
- refresh the Insight view from IndexedDB before running AI analysis and surface helpful error states
- rewrite the PDF export to render Japanese text via canvas imagery and ensure JSON exports include a UTF-8 BOM
- ignore the TypeScript build info artifact created during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3971db67c832a80ca3ec48a9f0c54