### PR TITLE
Remove data export features and enhance map labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "react-router-dom": "^6.26.2",
     "dexie": "^4.0.7",
     "cytoscape": "^3.28.1",
-    "jspdf": "^2.5.1",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/src/pages/Insight.tsx
+++ b/src/pages/Insight.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { db, IdeaFragment } from '../db/db'
 import { insightForCluster } from '../services/ai'
-import { jsPDF } from 'jspdf'
 
 type InsightPayload = { summary: string; next_steps: string[]; titles: string[] }
 
@@ -47,29 +46,6 @@ export default function Insight() {
     }
   }
 
-  async function exportJson() {
-    try {
-      setError(null)
-      const latestRows = await refreshRows()
-      if (!latestRows.length) {
-        setError('エクスポートできるデータがありません。')
-        return
-      }
-      const blob = new Blob(['\ufeff', JSON.stringify(latestRows, null, 2)], {
-        type: 'application/json;charset=utf-8'
-      })
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = `ideacloud-export-${Date.now()}.json`
-      a.click()
-      URL.revokeObjectURL(url)
-    } catch (err) {
-      console.error(err)
-      setError('JSONエクスポートに失敗しました。')
-    }
-  }
-
   async function importJson(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (!file) return
@@ -81,61 +57,6 @@ export default function Insight() {
     })
     await refreshRows()
     e.target.value = ''
-  }
-
-  async function exportPdf() {
-    try {
-      setError(null)
-      const latestRows = await refreshRows()
-      if (!latestRows.length) {
-        setError('エクスポートできるデータがありません。')
-        return
-      }
-
-      const doc = new jsPDF({ unit: 'pt', format: 'a4' })
-      const pageWidth = doc.internal.pageSize.getWidth()
-      const pageHeight = doc.internal.pageSize.getHeight()
-      const margin = 40
-      const contentWidth = pageWidth - margin * 2
-      const sections: HTMLCanvasElement[] = []
-
-      sections.push(createHeaderSection(contentWidth, latestRows))
-
-      if (ins) {
-        sections.push(
-          createParagraphSection(contentWidth, '要約', ins.summary, {
-            fallback: '要約がまだ生成されていません。'
-          })
-        )
-        sections.push(createListSection(contentWidth, '次の一手', ins.next_steps, '提案はまだありません。'))
-        sections.push(createListSection(contentWidth, 'タイトル候補', ins.titles, 'タイトル案はまだありません。'))
-      } else {
-        sections.push(
-          createParagraphSection(
-            contentWidth,
-            'インサイト',
-            'まだインサイトが生成されていません。上のボタンから生成を開始してください。'
-          )
-        )
-      }
-
-      let cursorY = margin
-      sections.forEach(canvas => {
-        const imgData = canvas.toDataURL('image/png')
-        const imgHeight = (canvas.height / canvas.width) * contentWidth
-        if (cursorY + imgHeight > pageHeight - margin) {
-          doc.addPage()
-          cursorY = margin
-        }
-        doc.addImage(imgData, 'PNG', margin, cursorY, contentWidth, imgHeight, undefined, 'FAST')
-        cursorY += imgHeight + 16
-      })
-
-      doc.save(`ideacloud-insight-${Date.now()}.pdf`)
-    } catch (err) {
-      console.error(err)
-      setError('PDF出力に失敗しました。ブラウザがCanvas描画に対応しているか確認してください。')
-    }
   }
 
   const statCards = useMemo(
@@ -154,7 +75,7 @@ export default function Insight() {
           <div>
             <h2 className="text-2xl font-semibold text-white">インサイトダッシュボード</h2>
             <p className="mt-2 max-w-xl text-sm text-slate-300">
-              AIが要約・次のアクション・タイトル案を提案します。データをエクスポートして他のツールと連携することもできます。
+              AIが要約・次のアクション・タイトル案を提案します。結果はダッシュボード上でいつでも確認できます。
             </p>
           </div>
           <div className="flex flex-wrap gap-3">
@@ -165,22 +86,10 @@ export default function Insight() {
             >
               {loading ? '生成中…' : 'インサイトを生成'}
             </button>
-            <button
-              onClick={() => void exportJson()}
-              className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-slate-900/60 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/60 hover:text-white"
-            >
-              JSONエクスポート
-            </button>
             <label className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-dashed border-white/20 bg-slate-900/60 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/60 hover:text-white">
               JSONインポート
               <input type="file" accept="application/json" onChange={importJson} className="hidden" />
             </label>
-            <button
-              onClick={() => void exportPdf()}
-              className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-slate-900/60 px-5 py-3 text-sm font-semibold text-slate-200 transition hover:border-cyan-300/60 hover:text-white"
-            >
-              PDF出力
-            </button>
           </div>
           {error && (
             <p className="text-sm text-rose-300" role="alert">
@@ -240,221 +149,4 @@ export default function Insight() {
       </section>
     </div>
   )
-}
-
-const CANVAS_DPI = 2
-const FONT_FAMILY = '"Noto Sans JP", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", "MS PGothic", sans-serif'
-
-function createHeaderSection(width: number, rows: IdeaFragment[]) {
-  const canvasWidth = Math.round(width * CANVAS_DPI)
-  const paddingX = 28 * CANVAS_DPI
-  const paddingY = 32 * CANVAS_DPI
-  const titleSize = 26 * CANVAS_DPI
-  const subtitleSize = 12 * CANVAS_DPI
-  const statLabelSize = 11 * CANVAS_DPI
-  const statValueSize = 20 * CANVAS_DPI
-  const statGap = 24 * CANVAS_DPI
-  const canvasHeight = paddingY * 2 + titleSize + subtitleSize + statValueSize + 60 * CANVAS_DPI
-  const canvas = document.createElement('canvas')
-  canvas.width = canvasWidth
-  canvas.height = canvasHeight
-  const ctx = canvas.getContext('2d')
-  if (!ctx) throw new Error('Canvas 2D contextが利用できません。')
-
-  ctx.fillStyle = '#0f172a'
-  ctx.fillRect(0, 0, canvas.width, canvas.height)
-
-  setCanvasFont(ctx, titleSize, 'bold')
-  ctx.fillStyle = '#e2e8f0'
-  let cursorY = paddingY + titleSize
-  ctx.fillText('IdeaCloud Insight', paddingX, cursorY)
-
-  setCanvasFont(ctx, subtitleSize, 'normal')
-  ctx.fillStyle = 'rgba(226, 232, 240, 0.8)'
-  cursorY += subtitleSize + 16 * CANVAS_DPI
-  ctx.fillText(new Date().toLocaleString('ja-JP'), paddingX, cursorY)
-
-  const stats = [
-    { label: '断片総数', value: rows.length },
-    {
-      label: '保存済みクラスタ',
-      value: new Set(rows.map(r => r.clusterId).filter(Boolean)).size
-    },
-    {
-      label: 'タグ多様性',
-      value: new Set(rows.flatMap(r => r.tags || [])).size
-    }
-  ]
-
-  const statWidth = (canvasWidth - paddingX * 2 - statGap * (stats.length - 1)) / stats.length
-  cursorY += 30 * CANVAS_DPI
-
-  stats.forEach((stat, index) => {
-    const x = paddingX + index * (statWidth + statGap)
-    ctx.fillStyle = 'rgba(148, 163, 184, 0.75)'
-    setCanvasFont(ctx, statLabelSize, 'normal')
-    ctx.fillText(stat.label, x, cursorY)
-    setCanvasFont(ctx, statValueSize, 'bold')
-    ctx.fillStyle = '#f8fafc'
-    ctx.fillText(String(stat.value), x, cursorY + 28 * CANVAS_DPI)
-  })
-
-  return canvas
-}
-
-function createParagraphSection(
-  width: number,
-  title: string,
-  text: string,
-  options?: { fallback?: string }
-) {
-  const canvasWidth = Math.round(width * CANVAS_DPI)
-  const paddingX = 28 * CANVAS_DPI
-  const paddingY = 28 * CANVAS_DPI
-  const titleSize = 20 * CANVAS_DPI
-  const bodySize = 14 * CANVAS_DPI
-  const lineHeight = Math.round(bodySize * 1.6)
-  const contentWidth = canvasWidth - paddingX * 2
-  const measure = document.createElement('canvas').getContext('2d')
-  if (!measure) throw new Error('Canvas 2D contextが利用できません。')
-
-  const sourceText = text && text.trim().length ? text : options?.fallback ?? ''
-  const lines = wrapCanvasText(sourceText, contentWidth, bodySize, measure)
-  const canvasHeight = paddingY * 2 + titleSize + 16 * CANVAS_DPI + Math.max(lineHeight, lines.length * lineHeight)
-  const canvas = document.createElement('canvas')
-  canvas.width = canvasWidth
-  canvas.height = canvasHeight
-  const ctx = canvas.getContext('2d')
-  if (!ctx) throw new Error('Canvas 2D contextが利用できません。')
-
-  ctx.fillStyle = '#f8fafc'
-  ctx.fillRect(0, 0, canvas.width, canvas.height)
-
-  setCanvasFont(ctx, titleSize, 'bold')
-  ctx.fillStyle = '#0f172a'
-  let cursorY = paddingY + titleSize
-  ctx.fillText(title, paddingX, cursorY)
-
-  setCanvasFont(ctx, bodySize, 'normal')
-  ctx.fillStyle = '#1e293b'
-  cursorY += 16 * CANVAS_DPI
-
-  if (!lines.length) {
-    ctx.fillText('内容がありません。', paddingX, cursorY + lineHeight)
-  } else {
-    lines.forEach(line => {
-      if (!line) {
-        cursorY += lineHeight
-      } else {
-        cursorY += lineHeight
-        ctx.fillText(line, paddingX, cursorY)
-      }
-    })
-  }
-
-  return canvas
-}
-
-function createListSection(width: number, title: string, items: string[], emptyMessage: string) {
-  if (!items.length) {
-    return createParagraphSection(width, title, emptyMessage)
-  }
-
-  const canvasWidth = Math.round(width * CANVAS_DPI)
-  const paddingX = 28 * CANVAS_DPI
-  const paddingY = 28 * CANVAS_DPI
-  const titleSize = 18 * CANVAS_DPI
-  const bodySize = 14 * CANVAS_DPI
-  const lineHeight = Math.round(bodySize * 1.6)
-  const bulletIndent = 20 * CANVAS_DPI
-  const contentWidth = canvasWidth - paddingX * 2 - bulletIndent
-  const measure = document.createElement('canvas').getContext('2d')
-  if (!measure) throw new Error('Canvas 2D contextが利用できません。')
-
-  const wrappedLines: { text: string; indent: number }[] = []
-  items.forEach((item, itemIndex) => {
-    const segments = wrapCanvasText(item, contentWidth, bodySize, measure)
-    segments.forEach((segment, segmentIndex) => {
-      if (!segment) {
-        wrappedLines.push({ text: '', indent: 0 })
-        return
-      }
-      if (segmentIndex === 0) {
-        wrappedLines.push({ text: `・ ${segment}`, indent: 0 })
-      } else {
-        wrappedLines.push({ text: segment, indent: bulletIndent })
-      }
-    })
-    if (itemIndex < items.length - 1) {
-      wrappedLines.push({ text: '', indent: 0 })
-    }
-  })
-
-  const lineCount = wrappedLines.length || 1
-  const canvasHeight = paddingY * 2 + titleSize + 16 * CANVAS_DPI + lineCount * lineHeight
-  const canvas = document.createElement('canvas')
-  canvas.width = canvasWidth
-  canvas.height = canvasHeight
-  const ctx = canvas.getContext('2d')
-  if (!ctx) throw new Error('Canvas 2D contextが利用できません。')
-
-  ctx.fillStyle = '#f1f5f9'
-  ctx.fillRect(0, 0, canvas.width, canvas.height)
-
-  setCanvasFont(ctx, titleSize, 'bold')
-  ctx.fillStyle = '#0f172a'
-  let cursorY = paddingY + titleSize
-  ctx.fillText(title, paddingX, cursorY)
-
-  setCanvasFont(ctx, bodySize, 'normal')
-  ctx.fillStyle = '#1e293b'
-  cursorY += 16 * CANVAS_DPI
-
-  wrappedLines.forEach(line => {
-    cursorY += lineHeight
-    if (!line.text) return
-    ctx.fillText(line.text, paddingX + line.indent, cursorY)
-  })
-
-  return canvas
-}
-
-function wrapCanvasText(
-  text: string,
-  maxWidth: number,
-  fontSize: number,
-  ctx: CanvasRenderingContext2D
-) {
-  const result: string[] = []
-  setCanvasFont(ctx, fontSize, 'normal')
-  const paragraphs = text.split(/\r?\n/)
-  paragraphs.forEach((paragraph, index) => {
-    if (!paragraph.trim()) {
-      if (result.length) result.push('')
-      return
-    }
-    let current = ''
-    for (const ch of paragraph) {
-      const next = current + ch
-      if (ctx.measureText(next).width > maxWidth && current) {
-        result.push(current)
-        current = ch
-      } else {
-        current = next
-      }
-    }
-    if (current) {
-      result.push(current)
-    }
-    if (index < paragraphs.length - 1) {
-      result.push('')
-    }
-  })
-  return result
-}
-
-function setCanvasFont(ctx: CanvasRenderingContext2D, size: number, weight: 'normal' | 'bold') {
-  const numericWeight = weight === 'bold' ? 600 : 400
-  ctx.font = `${numericWeight} ${size}px ${FONT_FAMILY}`
-  ctx.textBaseline = 'alphabetic'
 }

--- a/src/pages/MapView.tsx
+++ b/src/pages/MapView.tsx
@@ -45,9 +45,13 @@ export default function MapView() {
   }
 
   function buildElements(list: IdeaFragment[]): ElementsDefinition {
-    const nodes = list.map(f => ({
-      data: { id: f.id, label: f.text.slice(0, 32) || '…', clusterId: f.clusterId || 'none' }
-    }))
+    const nodes = list.map(f => {
+      const trimmed = (f.text || '').trim()
+      const label = trimmed.length > 60 ? `${trimmed.slice(0, 60)}…` : trimmed || '…'
+      return {
+        data: { id: f.id, label, clusterId: f.clusterId || 'none' }
+      }
+    })
     const edges: any[] = [] // MVP: 関連は将来
     return { nodes, edges }
   }
@@ -59,18 +63,25 @@ export default function MapView() {
     ids.forEach((id, i) => (colorBy[id] = palette[i % palette.length]))
     return {
       label: 'data(label)',
-      'font-size': 12,
+      'font-size': 13,
+      'font-family': '"Noto Sans JP", "Hiragino Kaku Gothic ProN", "Meiryo", sans-serif',
       'text-wrap': 'wrap',
-      'text-max-width': 120,
+      'text-max-width': '140px',
+      'text-valign': 'top',
+      'text-halign': 'center',
+      'text-margin-y': -14,
+      'text-background-color': 'rgba(15,23,42,0.75)',
+      'text-background-shape': 'roundrectangle',
+      'text-background-opacity': 0.85,
       width: 16,
       height: 16,
       'border-width': 2,
       'border-color': 'rgba(15,118,110,0.6)',
       'background-color': (ele: any) => colorBy[ele.data('clusterId')] || '#94a3b8',
-      'color': '#0f172a',
+      color: '#e2e8f0',
       'font-weight': '600',
-      'text-outline-color': '#0f172a',
-      'text-outline-width': 3
+      'text-outline-color': 'rgba(15,23,42,0.7)',
+      'text-outline-width': 2
     } as any
   }
 


### PR DESCRIPTION
## Summary
- remove the JSON/PDF export utilities from the Insight dashboard so results stay within the web app
- improve map node rendering to show readable labels with Japanese font support
- drop the unused jsPDF dependency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3b40158f0832a8d7e0572f2b78620